### PR TITLE
Files ending in comments and lacking trailing newlines can cause strange side effects

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -79,7 +79,7 @@ module.exports = function assetManager (settings)
 
 					var content = '';
 					for (var i=0; i < contents.length; i++) {
-						content += contents[i];
+						content += contents[i] + "\n";
 					};
 					if (!group.debug) {
 						if (group.dataType.toLowerCase() === 'javascript' || group.dataType.toLowerCase() === 'js') {


### PR DESCRIPTION
This fixes a bizarre issue where if a JavaScript file ends in a single-line comment that lacks a newline at the end, the comment will subsume the first line of the next JavaScript file. The fix is to explicitly insert another newline between the contents of every asset file.
