### PR TITLE
Regular Expressions for files list

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -21,50 +21,62 @@ module.exports = function assetManager (settings) {
 		};
 	}
 
-	settings.forEach(function (group, groupName) {
-		var wildCardIndex = null,
-			exprs = [];
-
+	settings.forEach(function(group, groupName) {
+		var patterns = [],
+			insertions = [],
+			dirFiles,
+			includes;
+		
+		// Extract patterns from files options
 		group.files.forEach(function(fileName, index) {
-			var removeFile = function() { group.files.splice(index, 1); }
-			if (fileName.exec) {
-				exprs.push(fileName);
-				removeFile();
+			var pattern = null;
+			
+			if (fileName.exec) { // Got a RegEx
+				pattern = fileName;
 			} else if (fileName.trim() === '*') {
-				wildCardIndex = index;
-				removeFile();
+				pattern = /\.[a-z]+$/i; // Anything with a extension
+			}
+			
+			if (pattern) {
+				patterns.push({
+					pattern: pattern,
+					index: index
+				});
+				group.files.splice(index, 1);
 			}
 		});
-
-		if (wildCardIndex !== null || exprs.length) {
-			var dirFiles = fs.readdirSync(group.path);
-			var wildCardFiles = [];
-			dirFiles.forEach(function(wildCardFileName, index) {
-				var found = false,
-					include = false;
-					
-				group.files.forEach(function(fileName) {
-					if (fileName.trim && (wildCardFileName.trim() === fileName.trim())) {
-						found = true;
+		
+		if (patterns.length) {
+			dirFiles = fs.readdirSync(group.path);
+			
+			dirFiles.forEach(function(fileName, index) {
+				var alreadyIncluded = false,
+					matchedPattern = false;
+				
+				group.files.forEach(function(includedFile) {
+					if (alreadyIncluded || (includedFile.trim() === fileName.trim())) {
+						alreadyIncluded = true;
 					}
 				});
 				
-				if (!found && (wildCardIndex !== null && wildCardFileName.match(/\.[a-z]+$/i))) {
-					include = true;
-				} else if (!found && exprs.length) {
-					exprs.forEach(function(exp) {
-						if ( !include && exp.exec(wildCardFileName) ) {
-							include = true;
+				if (!alreadyIncluded) {
+					patterns.forEach(function(pattern) {
+						if (!matchedPattern && pattern.pattern.exec(fileName)) {
+							matchedPattern = pattern;
 						}
 					});
 				}
 				
-				if (include) {
-					wildCardFiles.push(wildCardFileName);
+				if (matchedPattern) {
+					insertions.push({
+						file: fileName,
+						index: matchedPattern.index
+					});
 				}
 			});
-			wildCardFiles.forEach(function(wildCardFileName) {
-				group.files.splice(wildCardIndex, 0, wildCardFileName);
+			
+			insertions.forEach(function(insertion, index) {
+				group.files.splice(insertion.index + index, 0, insertion.file);
 			});
 		}
 	});

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -22,26 +22,44 @@ module.exports = function assetManager (settings) {
 	}
 
 	settings.forEach(function (group, groupName) {
-		var wildCardIndex = null;
+		var wildCardIndex = null,
+			exprs = [];
 
 		group.files.forEach(function(fileName, index) {
-			if (fileName.trim() === '*') {
+			var removeFile = function() { group.files.splice(index, 1); }
+			if (fileName.exec) {
+				exprs.push(fileName);
+				removeFile();
+			} else if (fileName.trim() === '*') {
 				wildCardIndex = index;
-				group.files.splice(index, 1);
+				removeFile();
 			}
 		});
 
-		if (wildCardIndex !== null) {
+		if (wildCardIndex !== null || exprs.length) {
 			var dirFiles = fs.readdirSync(group.path);
 			var wildCardFiles = [];
 			dirFiles.forEach(function(wildCardFileName, index) {
-				var found = false;
+				var found = false,
+					include = false;
+					
 				group.files.forEach(function(fileName) {
-					if (wildCardFileName.trim() === fileName.trim()) {
+					if (fileName.trim && (wildCardFileName.trim() === fileName.trim())) {
 						found = true;
 					}
 				});
-				if (!found && wildCardFileName.match(/\.[a-z]+$/i)) {
+				
+				if (!found && (wildCardIndex !== null && wildCardFileName.match(/\.[a-z]+$/i))) {
+					include = true;
+				} else if (!found && exprs.length) {
+					exprs.forEach(function(exp) {
+						if ( !include && exp.exec(wildCardFileName) ) {
+							include = true;
+						}
+					});
+				}
+				
+				if (include) {
 					wildCardFiles.push(wildCardFileName);
 				}
 			});


### PR DESCRIPTION
I've added support for regular expressions in the file lists in addition to the existing wildcard. Files will be inserted in the correct order - for example below it'll drop in util first, then all files beginning with jquery, then app.js.

```
'example.js': {
    route: /\/static\/example.js/,
    path: './public/js/',
    dataType: 'js',
    files: [
        'util.js',
        /^jquery*/,
        'app.js'
    ]
},
```
