### PR TITLE
Double execution bug

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -58,13 +58,17 @@ module.exports = function assetManager (settings) {
 			if (group.preManipulate)
 			{
 				Object.keys(group.preManipulate).forEach(function(key) {
-					userAgentMatches.push(key);
+					if (userAgentMatches.indexOf(key) === -1) {
+						userAgentMatches.push(key);
+					}
 				});
 			}
 			if (group.postManipulate)
 			{
 				Object.keys(group.postManipulate).forEach(function(key) {
-					userAgentMatches.push(key);
+					if (userAgentMatches.indexOf(key) === -1) {
+						userAgentMatches.push(key);
+					}
 				});
 			}
 			if (!userAgentMatches.length)
@@ -255,7 +259,7 @@ module.exports = function assetManager (settings) {
 				}
 			}
 		});
-		
+
 		if (!found) {
 			next();
 		} else {


### PR DESCRIPTION
We talked about this on IRC. 
If both, preManipulate and postManipulate have '^' as userAgentMatch it gets added twice to the array userAgentMatches.

this means that everything in 
userAgentMatches.forEach(function(match) { 
will be executed twice, which doesn't seem to make much sense to me :)
