### PR TITLE
Make manipulate callbacks consistent

### DIFF
--- a/deps/cssmin.js
+++ b/deps/cssmin.js
@@ -28,7 +28,7 @@ YAHOO.compressor.cssmin = function (css, linebreakpos){
         token = '';
 
     // preserve strings so their content doesn't get accidentally minified
-    css = css.replace(/("([^\\"]|\\.|\\)*")|('([^\\']|\\.|\\)*')/g, function(match) {
+    css = css.replace(/("([^\\"\n]|\\.|\\)*")|('([^\\'\n]|\\.|\\)*')/g, function(match) {
         var quote = match[0];
         preservedTokens.push(match.slice(1, -1));
         return quote + "___YUICSSMIN_PRESERVED_TOKEN_" + (preservedTokens.length - 1) + "___" + quote;

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -231,7 +231,9 @@ module.exports = function assetManager (settings) {
 					}
 				})(fileContent, path, index, last);
 		} else if (manipulateInstructions && typeof manipulateInstructions === 'function') {
-			manipulateInstructions(fileContent, path, index, last, callback);
+			manipulateInstructions(fileContent, path, index, last, function(content) {
+				callback(null, content)
+			});
 		} else {
 			callback(null, fileContent);
 		}


### PR DESCRIPTION
When {pre,post}Manipulate is specified as an array, the callback
expects only the content, but when it is just a single handler
the callback expects an error as well as the content.

I would have preferred to use the nodejs pattern and include the error
but all connect-assetmanager-handlers only pass content so I went the
simpler route for now.
