### PR TITLE
Add cached gzip encoding

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -1,7 +1,6 @@
 var fs = require('fs')
-	, Buffer = require('buffer').Buffer
 	, request = require('request')
-	, gzip = require('./gzip')
+	, gzip = require('./gzip').gzip
 	, Step = require('step')
 	, jsmin = require('./../deps/jsmin').minify
 	, htmlmin = require('./../deps/htmlmin').minify

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -1,6 +1,7 @@
 var fs = require('fs')
 	, Buffer = require('buffer').Buffer
 	, request = require('request')
+	, gzip = require('./gzip')
 	, Step = require('step')
 	, jsmin = require('./../deps/jsmin').minify
 	, htmlmin = require('./../deps/htmlmin').minify
@@ -209,9 +210,32 @@ module.exports = function assetManager (settings) {
 					for (var i=0; i < contents.length; i++) {
 						content += contents[i];
 					};
-
-					cache[groupName][match].contentBuffer = new Buffer(content, 'utf8');
-					cache[groupName][match].contentLenght = cache[groupName][match].contentBuffer.length;
+					var assetCache = cache[groupName][match],
+					    buffer = new Buffer(content, 'utf8');
+							
+					assetCache.uncompressed = {
+						contentBuffer: buffer,
+						contentLength: buffer.length,
+						modified: assetCache.modified
+					};
+					
+					return assetCache;
+				}, function (err, assetCache) {
+					if(err) throw err;
+					if(group.serveModify) return true;
+					
+					var done = this;
+					gzip(assetCache.uncompressed.contentBuffer, function(err, buffer){
+						if(err) throw err;
+						
+						assetCache.compressed = {
+							gzip: true,
+							contentBuffer: buffer,
+							contentLength: buffer.length,
+							modified: assetCache.modified
+						};
+						done();
+					});
 				});
 			});
 		});
@@ -270,6 +294,11 @@ module.exports = function assetManager (settings) {
 			}, 100);
 		}
 	};
+	
+	this.acceptsGzip = function(req){
+		var accept = req.headers["accept-encoding"];
+		return accept && accept.toLowerCase().indexOf('gzip') >= 0;
+	}
 
 	function assetManager (req, res, next) {
 		var self = this;
@@ -294,11 +323,12 @@ module.exports = function assetManager (settings) {
 					Object.keys(cache[groupName]).forEach(function(match) {
 						if (!found && userAgent.match(new RegExp(match, 'i'))) {
 							found = true;
-							response = {
-								contentLenght: cache[groupName][match].contentLenght
-								, modified: cache[groupName][match].modified
-								, contentBuffer: cache[groupName][match].contentBuffer
-							};
+							var assetCache = cache[groupName][match];
+							if(!groupServed.serveModify && acceptsGzip(req)){
+								response = assetCache.compressed;
+							} else {
+								response = assetCache.uncompressed;
+							}
 						}
 					});
 				}
@@ -316,14 +346,20 @@ module.exports = function assetManager (settings) {
 				serveContent(response);
 			}
 			function serveContent(response) {
-				res.writeHead(200, {
+				var headers = {
 					'Content-Type': mimeType,
-					'Content-Length': response.contentLenght,
+					'Content-Length': response.contentLength,
 					'Last-Modified': response.modified,
 					'Date': (new Date).toUTCString(),
 					'Cache-Control': 'public max-age=' + 31536000,
 					'Expires': response.expires || (new Date(new Date().getTime()+63113852000)).toUTCString()
-				});
+				}
+
+				if(response.gzip){
+					headers['Content-Encoding'] = 'gzip';
+				}
+				
+				res.writeHead(200, headers);
 				res.end(response.contentBuffer);
 			}
 			return;

--- a/lib/gzip.js
+++ b/lib/gzip.js
@@ -1,7 +1,6 @@
-var child_process = require('child_process')
-  , Buffer = require('buffer').Buffer;
+var child_process = require('child_process');
 
-module.exports = function(buffer, callback){
+module.exports.gzip = function(buffer, callback){
 	var gzip = child_process.spawn('gzip', ['-9'])
 		, buffers = []
 		, stdErr = false;
@@ -27,7 +26,7 @@ module.exports = function(buffer, callback){
 			
 			content = new Buffer(length);
 			buffers.forEach(function(buff, i){
-				buff.copy(content, index, 0, buff.length);
+				buff.copy(content, index);
 				index += buff.length;
 			});
 			
@@ -37,6 +36,6 @@ module.exports = function(buffer, callback){
 		return callback(stdErr);
 	});
 	
-	gzip.stdin.write(buffer,'utf8');
+	gzip.stdin.write(buffer);
 	gzip.stdin.end();
 }

--- a/lib/gzip.js
+++ b/lib/gzip.js
@@ -1,0 +1,42 @@
+var child_process = require('child_process')
+  , Buffer = require('buffer').Buffer;
+
+module.exports = function(buffer, callback){
+	var gzip = child_process.spawn('gzip', ['-9'])
+		, buffers = []
+		, stdErr = false;
+	
+	gzip.stdout.on('data', function(chunk){
+		buffers.push(chunk);
+	});
+	
+	gzip.stderr.on('data', function(){
+		stdErr = true;
+		buffers.length = 0;
+	});
+	
+	gzip.on('exit', function(){
+		var length = 0
+			, index = 0
+			, content;
+			
+		if (buffers.length && !stdErr ){
+			buffers.forEach(function(buff){
+				length += buff.length;
+			});
+			
+			content = new Buffer(length);
+			buffers.forEach(function(buff, i){
+				buff.copy(content, index, 0, buff.length);
+				index += buff.length;
+			});
+			
+			buffers.length = 0;
+			return callback(null, content);
+		}
+		return callback(stdErr);
+	});
+	
+	gzip.stdin.write(buffer,'utf8');
+	gzip.stdin.end();
+}


### PR DESCRIPTION
Add cached gzip encoding support when the group doesn't have a serveModify handler.
Connect removed their gzip middleware, and I think it makes the most sense to have this implemented on the cache directly.
