### PR TITLE
Support for external files hosted on HTTPS

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -96,7 +96,7 @@ module.exports = function assetManager (settings) {
 						group.files.splice(index, 1);
 						return;
 					}
-					if (file.match(/^http:\/\//) || file.match(/^https:\/\//)) {
+					if (file.match(/^https?:\/\//)) {
 						return;
 					}
 					fs.watchFile(group.path + file, function (old, newFile) {
@@ -259,7 +259,7 @@ module.exports = function assetManager (settings) {
 
 	this.getFile = function (file, path, groupName, callback) {
 		var isExternal = false;
-		if (file && (file.match(/^http:\/\//) || file.match(/^https:\/\//))) {
+		if (file && file.match(/^https?:\/\//)) {
 			isExternal = true;
 		}
 

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -96,7 +96,7 @@ module.exports = function assetManager (settings) {
 						group.files.splice(index, 1);
 						return;
 					}
-					if (file.match(/^http:\/\//)) {
+					if (file.match(/^http:\/\//) || file.match(/^https:\/\//)) {
 						return;
 					}
 					fs.watchFile(group.path + file, function (old, newFile) {
@@ -259,7 +259,7 @@ module.exports = function assetManager (settings) {
 
 	this.getFile = function (file, path, groupName, callback) {
 		var isExternal = false;
-		if (file && file.match(/^http:\/\//)) {
+		if (file && (file.match(/^http:\/\//) || file.match(/^https:\/\//))) {
 			isExternal = true;
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name" : "connect-assetmanager",
   "description" : "Middleware for Connect (node.js) for handling your static assets.",
-  "version" : "0.0.21",
+  "version" : "0.0.22",
   "author" : "Mathias Pettersson <mape@mape.me>",
   "engines" : ["node"],
   "directories" : { "lib" : "./lib" },


### PR DESCRIPTION
useful for external jquery hosted by google, for one:

https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js
