### PR TITLE
Populate cacheTimestamps and cacheHashes

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -7,7 +7,6 @@ var fs = require('fs')
 	, cssmin = require('./../deps/cssmin').minify
 	, crypto = require('crypto');
 
-
 var cache = {}
 	, settings = {}
 	, cacheHashes = {}
@@ -17,6 +16,9 @@ module.exports = function assetManager (assets) {
 	var self = this;
 
 	settings = assets || settings;
+	if (!settings) {
+		throw new Exception('No asset groups found');
+	}
 
 	if (!settings.forEach) {
 		settings.forEach = function(callback) {

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -241,10 +241,7 @@ module.exports = function assetManager (assets) {
 					cache[groupName][match].contentLength = cache[groupName][match].contentBuffer.length;
 				});
 			});
-
 		});
-
-
 	};
 
 	this.manipulate = function (manipulateInstructions, fileContent, path, index, last, callback) {

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -6,12 +6,17 @@ var fs = require('fs')
 	, htmlmin = require('./../deps/htmlmin').minify
 	, cssmin = require('./../deps/cssmin').minify
 	, crypto = require('crypto');
-var cache = {};
 
-module.exports = function assetManager (settings) {
+
+var cache = {}
+	, settings = {}
+	, cacheHashes = {}
+	, cacheTimestamps = {};
+
+module.exports = function assetManager (assets) {
 	var self = this;
-	this.cacheTimestamps = {};
-	this.cacheHashes = {};
+
+	settings = assets || settings;
 
 	if (!settings.forEach) {
 		settings.forEach = function(callback) {
@@ -172,7 +177,7 @@ module.exports = function assetManager (settings) {
 						grouping();
 						return;
 					}
-					self.cacheTimestamps[groupName] = lastModified.getTime();
+					cacheTimestamps[groupName] = lastModified.getTime();
 					if (!cache[groupName]) {
 						cache[groupName] = {};
 					}
@@ -228,13 +233,16 @@ module.exports = function assetManager (settings) {
 						content += contents[i];
 					};
 
-					self.cacheHashes[groupName] = crypto.createHash('md5').update(content).digest('hex');
+					cacheHashes[groupName] = crypto.createHash('md5').update(content).digest('hex');
 
 					cache[groupName][match].contentBuffer = new Buffer(content, 'utf8');
 					cache[groupName][match].contentLength = cache[groupName][match].contentBuffer.length;
 				});
 			});
+
 		});
+
+
 	};
 
 	this.manipulate = function (manipulateInstructions, fileContent, path, index, last, callback) {
@@ -354,7 +362,8 @@ module.exports = function assetManager (settings) {
 		}
 	};
 
-	assetManager.cacheTimestamps = this.cacheTimestamps;
-	assetManager.cacheHashes = this.cacheHashes;
+	assetManager.cacheTimestamps = cacheTimestamps;
+	assetManager.cacheHashes = cacheHashes;
+
 	return assetManager;
 };


### PR DESCRIPTION
1. I made `settings` a module variable so that I can init `var assetManager = require('connect-assetmanager'); assetManager(assets)` in `app.js`, and just call `assetManager()` elsewhere without having to pass in `assets` again.
2. `cacheTimestamps` and `cacheHashes` are also made module variables. They were otherwise returning empty objects no matter where/when I invoked `assetManager()`.

Both changes assume that the asset groups only needs to be initialized once.
