### PR TITLE
Fix response headers

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -387,7 +387,7 @@ module.exports = function assetManager (assets) {
 					'Content-Length': response.contentLength,
 					'Last-Modified': response.modified,
 					'Date': (new Date).toUTCString(),
-					'Cache-Control': 'public max-age=' + 31536000,
+					'Cache-Control': 'public,max-age=' + 31536000,
 					'Expires': response.expires || (new Date(new Date().getTime()+63113852000)).toUTCString()
 				};
 

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -388,7 +388,8 @@ module.exports = function assetManager (assets) {
 					'Last-Modified': response.modified,
 					'Date': (new Date).toUTCString(),
 					'Cache-Control': 'public,max-age=' + 31536000,
-					'Expires': response.expires || (new Date(new Date().getTime()+63113852000)).toUTCString()
+					'Expires': response.expires || (new Date(new Date().getTime()+63113852000)).toUTCString(),
+					'Vary': 'Accept-Encoding'
 				};
 
 				if(response.encoding) {

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -396,8 +396,14 @@ module.exports = function assetManager (assets) {
 					headers['Content-Encoding'] = response.encoding
 				}
 
-				res.writeHead(200, headers);
-				res.end(response.contentBuffer);
+				if (req.headers['if-modified-since'] &&
+					Date.parse(req.headers['if-modified-since']) >= Date.parse(response.modified)) {
+					res.writeHead(304, headers);
+					res.end();
+				} else {
+					res.writeHead(200, headers);
+					res.end(response.contentBuffer);
+				}
 			}
 			return;
 		}


### PR DESCRIPTION
Cache-Control field value should be comma separated as per http://tools.ietf.org/html/rfc2616 (message-header field-value format).

Vary header should be added since content negotiation is supported.
http://stackoverflow.com/questions/7848796/what-does-varyaccept-encoding-mean
http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.44
