### PR TITLE
Match hash/timeStamp in route

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -185,6 +185,9 @@ module.exports = function assetManager (assets) {
 						return;
 					}
 					cacheTimestamps[groupName] = lastModified.getTime();
+					if (group.route.toString().match(/:cacheTimestamp/)) {
+						group.route = new RegExp(group.route.toString().replace(/:cacheTimestamp/, lastModified.getTime()));
+					}
 					if (!cache[groupName]) {
 						cache[groupName] = {};
 					}
@@ -241,6 +244,9 @@ module.exports = function assetManager (assets) {
 					};
 
 					cacheHashes[groupName] = crypto.createHash('md5').update(content).digest('hex');
+					if (group.route.toString().match(/:cacheHash/)) {
+						group.route = new RegExp(group.route.toString().replace(/:cacheHash/, cacheHashes[groupName]));
+					}
 
 					cache[groupName][match].encodings = {};
 					var encodings = cache[groupName][match].encodings;
@@ -336,6 +342,9 @@ module.exports = function assetManager (assets) {
 		var mimeType = 'text/plain';
 		var groupServed;
 		settings.forEach(function (group, groupName) {
+			if (typeof group.route === 'string') {
+				group.route = new RegExp(group.route);
+			}
 			if (group.route.test(req.url)) {
 				var userAgent = req.headers['user-agent'] || '';
 				groupServed = group;


### PR DESCRIPTION
This change allows you to match the current hash or timestamp in the URL route. Kind of an edge case for CDN origin servers, but putting the hash in the URL path guarantees that the current asset is served correctly during staggered releases across multiple load-balanced hosts, rather than relying on cache-invalidation with GET parameters.
