### PR TITLE
Load assets from sub folders

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -60,7 +60,42 @@ module.exports = function assetManager (assets) {
 			});
 
 			var fileFetchCallback = grouping();
-			fs.readdir(group.path, function(err, files) {
+
+			// default operation is normal directory read (= without subdirectories)
+			var fileListOperation = fs.readdir;
+			if(group.recursive){
+
+				// walk function inspired by: http://stackoverflow.com/questions/5827612/node-js-fs-readdir-recursive-directory-search
+				var baseDir = group.path;
+				fileListOperation = function(dir, done) {
+					var results = [];
+					fs.readdir(dir, function(err, list) {
+						if (err) return done(err);
+						var pending = list.length;
+						if (!pending) return done(null, results);
+						list.forEach(function(file) {
+							file = dir + '/' + file;
+							fs.stat(file, function(err, stat) {
+								if (stat && stat.isDirectory()) {
+									fileListOperation(file, function(err, res) {
+										results = results.concat(res);
+										if (!--pending) done(null, results);
+									});
+								} else {
+
+									// remove the base dir from the file path because the path should be starting from root directory of the assets
+									file = file.replace(baseDir,'');
+
+									results.push(file);
+									if (!--pending) done(null, results);
+								}
+							});
+						});
+					});
+				};
+			}
+
+			fileListOperation(group.path, function(err, files) {
 				if (err) {
 					throw err;
 				}


### PR DESCRIPTION
Currently adding assets from subfolders of the <i>path</i> setting is not supported. Applications often structure script files in subfolders to allow a better overview (community also asked for this: https://github.com/mape/connect-assetmanager/issues/47). 

The pull request introduces a new parameter <i>recursive</i>. If this parameter is set to true, files from path are loaded recursively. All other mechanism are applied as before. An example usage could look like this: 

``` javascript
var assetManagerGroups = {
    'js': {
        'debug': false,
        'route': /\/static\/js\/app.bundle.js/
        , 'path': './public/app/'
        ,recursive: true
        , 'dataType': 'javascript'
        , 'files': [/[a-zA-Z/]*.js/], 'postManipulate': {
            '^': [
                assetHandler.yuiJsOptimize
            ]
        }
    }
};
```

The parameter is necessary because loading files from sub directories could potentially break existing usages. 
