### PR TITLE
Added try/catch block around file watch.

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -111,11 +111,15 @@ module.exports = function assetManager (assets) {
 					if (file.match(/^https?:\/\//)) {
 						return;
 					}
-					fs.watch(group.path + file, function (event, file) {
-						if (event === 'change') {
-							self.generateCache(groupName);
-						}
-					});
+                    try {
+                        fs.watch(group.path + file, function (event, file) {
+                            if (event === 'change') {
+                                self.generateCache(groupName);
+                            }
+                        });
+                    }
+                    catch (err) {
+                    }
 				});
 			}
 		});


### PR DESCRIPTION
To alleviate error:

connect-assetmanager/node_modules/step/lib/step.js:39
        throw arguments[0];
                       ^
Error: watch ENOENT
    at errnoException (fs.js:1019:11)
    at FSWatcher.start (fs.js:1051:11)
    at Object.fs.watch (fs.js:1076:11)
    at connect-assetmanager/lib/assetmanager.js:115:24
    at Array.forEach (native)
    at connect-assetmanager/lib/assetmanager.js:105:17
    at connect-assetmanager/lib/assetmanager.js:32:6
    at Array.forEach (native)
    at Object.settings.forEach (connect-assetmanager/lib/assetmanager.js:30:22)
    at Function.<anonymous> (/connect-assetmanager/lib/assetmanager.js:103:12)
